### PR TITLE
Add pre-commit updater

### DIFF
--- a/.github/workflows/pre-commit-updater.yaml
+++ b/.github/workflows/pre-commit-updater.yaml
@@ -1,0 +1,32 @@
+name: Pre-commit Updater
+on:
+  schedule:
+    - cron: '0 4 * * 7'
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit autoupdate
+        run: pre-commit autoupdate
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-autoupdate
+          title: Auto-update pre-commit hooks
+          commit-message: Auto-update pre-commit hooks
+          body: |
+            Update versions of tools in pre-commit
+            configs to latest version
+          labels: dependencies

--- a/.github/workflows/pre-commit-updater.yaml
+++ b/.github/workflows/pre-commit-updater.yaml
@@ -1,7 +1,7 @@
 name: Pre-commit Updater
 on:
   schedule:
-    - cron: '0 4 * * 7'
+    - cron: '0 4 * * 0'
 jobs:
   auto-update:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Pre-commit Updater (GitHub Action)
+
 ## [0.1.0] - 2022-12-19
 
 ### Added


### PR DESCRIPTION
Due to Dependabot not looking into pre-commit configs (see https://github.com/dependabot/dependabot-core/issues/1524),  this adds a GitHub Action / workflow to check and update weekly. 

Based on https://browniebroke.com/blog/gh-action-pre-commit-autoupdate.