### PR TITLE
Update versioning in release tags

### DIFF
--- a/.act-payload.json
+++ b/.act-payload.json
@@ -1,0 +1,9 @@
+{
+    "//comment": "Event payload for local GitHub Action testing. See: https://github.com/nektos/act",
+    "repository": {
+        "full_name": "gtronset/beets-audiobooks"
+    },
+    "release": {
+        "tag_name": "v9.99.999-ba9"
+    }
+}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -31,18 +31,18 @@ jobs:
       - name: Docker Meta
         id: meta
         uses: docker/metadata-action@v4
-        env:
-          SEMVER: type=semver,value=${{ github.event.release.tag_name }}
         with:
           images: |
             ghcr.io/${{ github.event.repository.full_name }}
           tags: |
-            ${{ env.SEMVER }},pattern={{version}}
-            ${{ env.SEMVER }},pattern={{major}}.{{minor}}
-            ${{ env.SEMVER }},pattern={{major}}
+              type=match,value=${{ github.event.release.tag_name }},pattern=v(.*),group=1
+              type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+.\d+.\d+),group=1
+              type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+.\d+),group=1
+              type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+),group=1
 
       - name: Tags
         run: |
+              echo "Tags:"
               echo "${{ steps.meta.outputs.tags }}"
 
       #- name: Login to DockerHub


### PR DESCRIPTION
`metadata-action` correctly treats `-suffix` in SEMVER as prerelease information. This bypasses it to still generate the other tags needed.

All non `-ba#` tags are treated as the late version specified, all the way to `patch`.