### PR TITLE
Add/use PAT for auto-approve

### DIFF
--- a/.github/workflows/automerge-release.yaml
+++ b/.github/workflows/automerge-release.yaml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Approve
         uses: hmarr/auto-approve-action@v3.2.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v3
       - run: rm -rf .git/hooks


### PR DESCRIPTION
Since GitHub doesn't allow self-approvals on PRs, the auto-approver needs different permissions via [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).