### PR TITLE
Use PAT so Actions properly trigger

### DIFF
--- a/.github/workflows/automerge-release.yaml
+++ b/.github/workflows/automerge-release.yaml
@@ -48,7 +48,7 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
 
       - name: Approve
         uses: hmarr/auto-approve-action@v3.2.1
@@ -67,6 +67,7 @@ jobs:
         id: create-release
         uses: "actions/github-script@v6.4.1"
         with:
+          github-token: "${{ secrets.PAT }}"
           script: |
             const script = require('./.github/workflows/github-release/github-create-release.js')
             return await script({github, context, core})

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -33,7 +33,7 @@ jobs:
         env:
           TAG_NAME: ${{ env.TAG_NAME }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           branch: release/beets-audiobooks
           title: New Release - beets-audiobooks -> ${{ env.TAG_NAME }}
           commit-message: New Release - beets-audiobooks -> ${{ env.TAG_NAME }}

--- a/.github/workflows/update-baseimage.yaml
+++ b/.github/workflows/update-baseimage.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           branch: update/overdrive-autoupdate
           title: Auto-update BaseImage
           commit-message: Auto-update BaseImage


### PR DESCRIPTION
Actions creating PRs by default will not trigger additional actions. See https://github.com/peter-evans/create-pull-request/issues/48.

This uses a PAT instead so that other CI tests are properly triggered.