### PR TITLE
Separate out the release action to be actually actionable

### DIFF
--- a/.act-payload.json
+++ b/.act-payload.json
@@ -8,5 +8,9 @@
     },
     "label": {
         "name": "release"
+    },
+    "pull_request": {
+        "title": "New Release - beets-audiobooks -> v9.99.999-ba9",
+        "merged": true
     }
 }

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -15,7 +15,9 @@ jobs:
 
   test_docker_container:
     name: Build and Test Docker image
-    if: github.event.label.name == 'release'
+    if: |
+      startsWith(github.event.pull_request.title, 'New Release - beets-audiobooks -> v') &&
+      github.event.label.name == 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -39,7 +41,9 @@ jobs:
           docker run --rm -i ${{ env.TEST_TAG }} beet version
 
   automerge_release_pr:
-    if: github.event.label.name == 'release'
+    if: |
+      startsWith(github.event.pull_request.title, 'New Release - beets-audiobooks -> v') &&
+      github.event.label.name == 'release'
     needs: test_docker_container
     runs-on: ubuntu-latest
 

--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           docker run --rm -i ${{ env.TEST_TAG }} beet version
 
-  automerge_release:
+  automerge_release_pr:
     if: github.event.label.name == 'release'
     needs: test_docker_container
     runs-on: ubuntu-latest
@@ -60,20 +60,3 @@ jobs:
         uses: hmarr/auto-approve-action@v3.2.1
         with:
           github-token: ${{ steps.get_bot_token.outputs.token }}
-
-      - uses: actions/checkout@v3
-      - run: rm -rf .git/hooks
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-      - run: npm install js-yaml
-
-      - name: "Release"
-        id: create-release
-        uses: "actions/github-script@v6.4.1"
-        with:
-          github-token: "${{ secrets.PAT }}"
-          script: |
-            const script = require('./.github/workflows/github-release/github-create-release.js')
-            return await script({github, context, core})

--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PYTHON_VERSION: 3.11
+  POETRY_VERSION: 1.4.2
+
+jobs:
+
+  autorelease:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: rm -rf .git/hooks
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm install js-yaml
+
+      # Need to restrict to just pushs from the release PRs.
+      # - name: "Release"
+      #   id: create-release
+      #   uses: "actions/github-script@v6.4.1"
+      #   with:
+      #     github-token: "${{ secrets.PAT }}"
+      #     script: |
+      #       const script = require('./.github/workflows/github-release/github-create-release.js')
+      #       return await script({github, context, core})

--- a/.github/workflows/autorelease.yaml
+++ b/.github/workflows/autorelease.yaml
@@ -1,9 +1,12 @@
 name: Release
 
 on:
-  push:
+  pull_request_target:
     branches:
-      - main
+      - 'main'
+    types:
+      - closed
+
 
 env:
   PYTHON_VERSION: 3.11
@@ -12,7 +15,12 @@ env:
 jobs:
 
   autorelease:
-    name: Release
+    name: AutoRelease
+    if: |
+      startsWith(github.event.pull_request.title, 'New Release - beets-audiobooks -> v') &&
+      github.event.label.name == 'release' &&
+      github.event.pull_request.merged == true
+
     runs-on: ubuntu-latest
 
     steps:
@@ -24,12 +32,11 @@ jobs:
           node-version: 16
       - run: npm install js-yaml
 
-      # Need to restrict to just pushs from the release PRs.
-      # - name: "Release"
-      #   id: create-release
-      #   uses: "actions/github-script@v6.4.1"
-      #   with:
-      #     github-token: "${{ secrets.PAT }}"
-      #     script: |
-      #       const script = require('./.github/workflows/github-release/github-create-release.js')
-      #       return await script({github, context, core})
+      - name: "Release"
+        id: create-release
+        uses: "actions/github-script@v6.4.1"
+        with:
+          github-token: "${{ secrets.PAT }}"
+          script: |
+            const script = require('./.github/workflows/github-release/github-create-release.js')
+            return await script({github, context, core})

--- a/.github/workflows/trigger-release.yaml
+++ b/.github/workflows/trigger-release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: "Release"
+    name: Trigger Release"
 
     runs-on: "ubuntu-latest"
 
@@ -20,7 +20,7 @@ jobs:
           node-version: 16
       - run: npm install js-yaml
 
-      - name: "Prep for Release"
+      - name: "Trigger Release"
         id: release_prep
         uses: "actions/github-script@v6.4.1"
         with:


### PR DESCRIPTION
This allows the release part of the action to occur _after_ the release PR is merged, hopefully fixing the automation.