### PR TITLE
Deprecate linux/arm/v7

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - "main"
 
 permissions:
   contents: read
@@ -43,7 +43,7 @@ jobs:
 
       - name: Tags
         run: |
-              echo "${{ steps.meta.outputs.tags }}"
+          echo "${{ steps.meta.outputs.tags }}"
 
       #- name: Login to DockerHub
       #  uses: docker/login-action@v3
@@ -73,7 +73,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: ${{ env.SHOULD_PUBLISH }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -35,15 +35,15 @@ jobs:
           images: |
             ghcr.io/${{ github.event.repository.full_name }}
           tags: |
-              type=match,value=${{ github.event.release.tag_name }},pattern=v(.*),group=1
-              type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+.\d+.\d+),group=1
-              type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+.\d+),group=1
-              type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+),group=1
+            type=match,value=${{ github.event.release.tag_name }},pattern=v(.*),group=1
+            type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+.\d+.\d+),group=1
+            type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+.\d+),group=1
+            type=match,value=${{ github.event.release.tag_name }},pattern=v(\d+),group=1
 
       - name: Tags
         run: |
-              echo "Tags:"
-              echo "${{ steps.meta.outputs.tags }}"
+          echo "Tags:"
+          echo "${{ steps.meta.outputs.tags }}"
 
       #- name: Login to DockerHub
       #  uses: docker/login-action@v3
@@ -73,7 +73,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: linux/arm/v7,linux/arm64,linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf). This was deprecated as of https://github.com/linuxserver/docker-beets/releases/tag/1.6.0-ls178